### PR TITLE
threads.php, recents.php

### DIFF
--- a/database/boards.php
+++ b/database/boards.php
@@ -30,15 +30,6 @@ $config['boards']['test'] = array(
 	'type' => 'img'
 );
 
-$config['boards']['1'] = array(
-	'url' => '1',
-	'title' => '1GET',
-	'description' => '1st!!',
-	'locked' => 1,
-	'hidden' => 0,
-	'type' => 'img'
-);
-
 
 foreach ($config['boards'] as $boards) {
 	$config['boardlist'][] = $boards['url'];

--- a/delete-report.php
+++ b/delete-report.php
@@ -64,9 +64,9 @@ if (isset($delrep_thread) && (!file_exists($path . '/' . $database_folder . '/bo
 
 if (isset($_POST["delete"]) && $_POST["delete"] != "") {
 	if (isset($_POST['file'])) { //file only?
-		DeletePost($database_folder, $uploads_folder, $delrep_board, $delrep_thread, $delrep_reply, true, $secure_hash);
+		DeletePost($database_folder, $uploads_folder, $delrep_board, $delrep_thread, $delrep_reply, true, $secure_hash, $recent_replies);
 	} else {
-		DeletePost($database_folder, $uploads_folder, $delrep_board, $delrep_thread, $delrep_reply, false, $secure_hash);
+		DeletePost($database_folder, $uploads_folder, $delrep_board, $delrep_thread, $delrep_reply, false, $secure_hash, $recent_replies);
 	}
 }
 

--- a/includes/default.php
+++ b/includes/default.php
@@ -24,6 +24,9 @@ $display_id = true;
 $disable_email = false; //Disables the email field. Checkboxes will still work.
 $show_email = true; //shows email in post name
 
+$recent_replies = 5; //how many recent replies to show on index
+$threads_page = 10; //how many threads per page
+
 $max_filesize = 1024*1000*8; //default 8mb
 $max_filename = 28; //longer than this will be trimmed visually, absolute max is set to 512 at which point it is trimmed when saved as well. you can see untrimmed below 512 by hovering over name
 

--- a/main.php
+++ b/main.php
@@ -87,65 +87,34 @@ if (in_Array(htmlspecialchars($_GET["board"]), $config['boardlist'])) {
 			exit();
 		}
 
-		//FIND THREADS
-		$threads_full = [];
-		$threads_full = glob(__dir__ . '/' . $database_folder . '/boards/' . $current_board . "/*", GLOB_ONLYDIR);
-		
-		//SORTING
-		foreach ($threads_full as $key => $thread) {
-			$threadz= basename($thread);
-			if (!file_exists(__dir__ . '/' . $database_folder . '/boards/' . $current_board . '/' . basename($thread) . '/bumped.php')) {
-				$bumped = basename($thread);
-			}
-			if (file_exists(__dir__ . '/' . $database_folder . '/boards/' . $current_board . '/' . basename($thread) . '/bumped.php')) {
-				$bumped = file_get_contents(__dir__ . '/' . $database_folder . '/boards/' . $current_board . '/' . basename($thread) . '/bumped.php');
-			}
-			$threads[$key] = [];
-			$threads[$key]['id'] = $threadz;
-			$threads[$key]['bumped'] = $bumped;
-		}
-		$keys_ = array_column($threads, 'bumped');
-		array_multisort($keys_, SORT_DESC, $threads);
+		include __dir__ . '/' . $database_folder . '/boards/' . $current_board . '/threads.php';
 
-		////// to do: use post/mod.php to allow for a sticky 0/1, locked 0/1, if sticky show 0-1 replies max
+		//show max threads only
+		//if page = 1
+		if (count($threads) > $threads_page) {
+		$total_threads = count($threads);
+		$threads = array_slice($threads, 0, $threads_page);
+		$hidden_threads = $total_threads - $threads_page;
+		echo 'There are ' . $hidden_threads . ' undisplayed threads. I\'ll make a pagination for them all...' ;
+		}
+		//create extra pages?
+
 
 		//SHOW THEM
 		foreach (array_keys($threads) as $key => $value) {
 			include __dir__ . '/' . $database_folder . '/boards/' . $current_board . '/' . $threads[$key]['id'] . '/OP.php';
 			include __dir__ . '/' . $database_folder . '/boards/' . $current_board . '/' . $threads[$key]['id'] . '/info.php';
+			include __dir__ . '/' . $database_folder . '/boards/' . $current_board . '/' . $threads[$key]['id'] . '/recents.php';
 			$post_number_op = $threads[$key]['id'];
-
-			//SHOW REPLIES TO THREADS ON INDEX (im gonna need a lot of changes here later for sorting and maximum, configurable recents.php updated by post.php for performance?)
-				//ADD ALL REPLIES HERE
-			//FIND REPLIES
-				$replies_full = [];
-				$replies_full = glob(__dir__ . '/' . $database_folder . '/boards/' . $current_board . '/' . $post_number_op . "/*");
-			//SORTING
-				$replies = [];
-				foreach ($replies_full as $reply) {
-					//file in folder is numeric = reply
-					if (is_numeric(basename($reply, '.php'))) {
-						$replies[] = basename($reply, '.php');
-					}
-				}
-			$total_replies = count($replies);
-			rsort($replies); //sort by biggest to lowest
-			$replies = array_slice($replies, 0, 5); //remove everything except biggest
-			sort($replies); //sort back to show from low to high
-
-			if ($total_replies > 5) {
-				$replies_omitted = $total_replies - count($replies);
-			} else {
-				$replies_omitted = 0;
-			}
 
 			echo '<div data-thread="' . $post_number_op . '" class="container">';
 			//SHOW THREADS
 			include $path . '/templates/thread.html';
 			//SHOW SHOW REPLIES
-			foreach (array_keys($replies) as $rkey => $value) {
-				include __dir__ . '/' . $database_folder . '/boards/' . $current_board . '/' . $post_number_op . '/' . $replies[$value] . '.php';
-				$post_number_reply = $replies[$value];
+
+			foreach (array_keys($recents) as $rkey => $value) {
+				include __dir__ . '/' . $database_folder . '/boards/' . $current_board . '/' . $post_number_op . '/' . $recents[$value] . '.php';
+				$post_number_reply = $recents[$value];
 				include $path . '/templates/reply.html';
 		   	}
 		   	echo '</div>';

--- a/post.php
+++ b/post.php
@@ -192,6 +192,8 @@ if ((isset($post_board)) && (isset($_POST['index']))) {
 	//
 
 	UpdateOP($database_folder, $post_board, $current_count, 1, 0, $current_count, 1); //information about thread and replies
+	UpdateThreads($database_folder, $post_board, $current_count); //update recents.php and board bumps.
+	UpdateRecents($database_folder, $post_board, $current_count, $recent_replies);
 	include __dir__ . '/includes/update-frontpage.php';
 	PostSuccess($prefix_folder . $main_file . '/?board=' . $post_board . '&thread=' . $counter . '#' . $counter, true);
 	
@@ -266,6 +268,7 @@ if ((isset($post_board)) && (isset($_POST['thread']))) {
 
 
 		UpdateOP($database_folder, $post_board, $post_thread_number, 0, $reply_counter, $current_count, $ip_counter);
+		UpdateRecents($database_folder, $post_board, $post_thread_number, $recent_replies); //update recents.php and board bumps.
 		include __dir__ . '/includes/update-frontpage.php';
 		PostSuccess($prefix_folder . $main_file . '/?board=' . $post_board . '&thread=' . $post_thread_number . '#' . $current_count, true);
 		


### PR DESCRIPTION
now index page pulls replies from a list of recent replies in that thread, and threads from a list of all threads. no need to check every thread and every reply on index page anymore, will help performance in the long run. already had much longer loading times at 30 threads, now its almost same as the other ones pretty much.
good performance boost, 5x faster, cannot imagine how bad it would get at 10-100 threads each with 1-100 replies lmao, or even more fuck

close #5 