### PR TITLE
post buttons safari fix

### DIFF
--- a/assets/css/Yotsuba B.css
+++ b/assets/css/Yotsuba B.css
@@ -572,6 +572,13 @@ div.post details table {
 details summary::marker {
   content: '';
 }
+
+/*marker animations do not work on safari for mac+ios as of 2021/12/27. Compat fix */
+summary::-webkit-details-marker {
+	display: none;
+}
+/* end fix */
+
 details summary:before, details[open] details summary:before, details[open] details[open] details summary:before {
   content: '▲';
   font-size: 10pt;


### PR DESCRIPTION
https://caniuse.com/?search=%3A%3Amarker
no animations, but this will at least prevent duplicate buttons for safari on mac+iphone.